### PR TITLE
feat: inline sponsorship form instead of external google forms

### DIFF
--- a/site/src/commonMain/libres/strings/conference_strings_en.xml
+++ b/site/src/commonMain/libres/strings/conference_strings_en.xml
@@ -31,6 +31,7 @@
     <string name="conf_sponsor_caption">This event would not be possible without your help. Would you like to support the community and introduce your company to our entire audience?</string>
     <string name="conf_sponsor_im_interested">I'm interested</string>
     <string name="conf_sponsor_i_want_to_sponsor">I want to be an sponsor</string>
+    <string name="conf_sponsor_form_uid">327e2a365b</string>
 
     <!-- Conference Sponsorship -->
     <string name="conf_sponsorship_title">Interested in Sponsoring?</string>

--- a/site/src/commonMain/libres/strings/conference_strings_es.xml
+++ b/site/src/commonMain/libres/strings/conference_strings_es.xml
@@ -31,6 +31,7 @@
     <string name="conf_sponsor_caption">Este evento no sería posible sin su ayuda. ¿Te gustaría apoyar a la comunidad y dar a conocer tu empresa a toda nuestra audiencia?</string>
     <string name="conf_sponsor_im_interested">Estoy interesado</string>
     <string name="conf_sponsor_i_want_to_sponsor">Quiero ser sponsor</string>
+    <string name="conf_sponsor_form_uid">e70a984a90</string>
 
     <!-- Conference Sponsorship -->
     <string name="conf_sponsorship_title">¿Interesado en ser patrocinador?</string>

--- a/site/src/jsMain/kotlin/web/android/dev/pe/Res.kt
+++ b/site/src/jsMain/kotlin/web/android/dev/pe/Res.kt
@@ -26,7 +26,6 @@ object Res {
         object Conf {
             const val MapUPC = "https://maps.app.goo.gl/WyPeqxmWyJS8bbvJ6"
             const val C4P = "https://www.papercall.io/adpday"
-            const val SponsorBrief = "https://docs.google.com/forms/d/e/1FAIpQLSfTA2fmZJyfLi6ssmoGtER-JwWor751g9BDhkrYQ_KjvJaWQw/viewform"
             const val Register = ""
         }
 

--- a/site/src/jsMain/kotlin/web/android/dev/pe/components/widgets/ConvertKitForm.kt
+++ b/site/src/jsMain/kotlin/web/android/dev/pe/components/widgets/ConvertKitForm.kt
@@ -1,0 +1,50 @@
+package web.android.dev.pe.components.widgets
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.attrsModifier
+import com.varabyte.kobweb.compose.ui.modifiers.display
+import com.varabyte.kobweb.compose.ui.modifiers.justifyContent
+import com.varabyte.kobweb.compose.ui.toAttrs
+import kotlinx.dom.appendElement
+import org.jetbrains.compose.web.css.DisplayStyle
+import org.jetbrains.compose.web.css.JustifyContent
+import org.jetbrains.compose.web.dom.Div
+import org.w3c.dom.Element
+
+
+/**
+ * Using script to load an inline ConvertKit form. For more info see:
+ * https://help.convertkit.com/en/articles/4009572-form-embedding-basics#javascript
+ */
+@Composable
+fun ConvertKitForm(uid: String, modifier: Modifier = Modifier) {
+    val containerRef = mutableStateOf(ContainerRef())
+
+    Div(Modifier
+        .display(DisplayStyle.Flex)
+        .justifyContent(JustifyContent.Center)
+        .attrsModifier {
+            ref {
+                containerRef.value = ContainerRef(it)
+                onDispose { containerRef.value = ContainerRef(null) }
+            }
+        }
+        .then(modifier)
+        .toAttrs()
+    )
+
+    LaunchedEffect(containerRef.value) {
+        containerRef.value.current?.let { container ->
+            container.appendElement("script") {
+                setAttribute("async", "")
+                setAttribute("data-uid", uid)
+                setAttribute("src", "https://android-dev-peru.ck.page/$uid/index.js")
+            }
+        }
+    }
+}
+
+private class ContainerRef(val current: Element? = null)

--- a/site/src/jsMain/kotlin/web/android/dev/pe/pages/conf/ConferenceLanding.kt
+++ b/site/src/jsMain/kotlin/web/android/dev/pe/pages/conf/ConferenceLanding.kt
@@ -2,9 +2,7 @@ package web.android.dev.pe.pages.conf
 
 import androidx.compose.runtime.Composable
 import com.varabyte.kobweb.core.Page
-import strings.ResStrings
 import web.android.dev.pe.components.ConferenceSite
-import web.android.dev.pe.components.utils.appendCurrentLanguage
 import web.android.dev.pe.pages.conf.components.sections.*
 import web.android.dev.pe.pages.home.components.layouts.AlternateBackground
 
@@ -30,8 +28,5 @@ private fun Content() {
     EventSection(AlternateBackground)
     LocationSection()
     CallForPapersSection(AlternateBackground)
-    SponsorSection(
-        ctaTitle = ResStrings.conf_sponsor_im_interested,
-        ctaPath = "/conf/sponsorship".appendCurrentLanguage(),
-    )
+    SponsorSection()
 }

--- a/site/src/jsMain/kotlin/web/android/dev/pe/pages/conf/components/sections/SponsorSection.kt
+++ b/site/src/jsMain/kotlin/web/android/dev/pe/pages/conf/components/sections/SponsorSection.kt
@@ -12,23 +12,18 @@ import org.jetbrains.compose.web.dom.H2
 import org.jetbrains.compose.web.dom.P
 import org.jetbrains.compose.web.dom.Text
 import strings.ResStrings
-import web.android.dev.pe.components.widgets.HeadingDecorator
+import web.android.dev.pe.components.utils.appendCurrentLanguage
 import web.android.dev.pe.components.widgets.OutlinePrimaryButtonVariant
 import web.android.dev.pe.components.widgets.PrimaryButton
 import web.android.dev.pe.pages.conf.components.layouts.ConferenceGridSection
 
 @Composable
-fun SponsorSection(
-    ctaTitle: String,
-    ctaPath: String,
-    sectionModifier: Modifier = Modifier,
-    modifier: Modifier = Modifier,
-) {
+fun SponsorSection(sectionModifier: Modifier = Modifier, modifier: Modifier = Modifier) {
     ConferenceGridSection(
         sectionModifier = sectionModifier,
         modifier = modifier,
         header = {
-            Details(ctaTitle, ctaPath)
+            Details()
         },
         content = {
             Sponsors()
@@ -38,15 +33,12 @@ fun SponsorSection(
 
 
 @Composable
-private fun Details(ctaTitle: String, ctaPath: String) {
-    H2 {
-        HeadingDecorator()
-        Text(ResStrings.conf_sponsor_title)
-    }
+private fun Details() {
+    H2 { Text(ResStrings.conf_sponsor_title) }
     P { Text(ResStrings.conf_sponsor_caption) }
     PrimaryButton(
-        text = ctaTitle,
-        href = ctaPath,
+        text = ResStrings.conf_sponsor_im_interested,
+        href = "/conf/sponsorship".appendCurrentLanguage(),
         modifier = Modifier.margin(topBottom = 16.px),
         variant = OutlinePrimaryButtonVariant,
     )

--- a/site/src/jsMain/kotlin/web/android/dev/pe/pages/conf/subpages/sponsorship/ConfSponsorship.kt
+++ b/site/src/jsMain/kotlin/web/android/dev/pe/pages/conf/subpages/sponsorship/ConfSponsorship.kt
@@ -12,13 +12,14 @@ import com.varabyte.kobweb.silk.style.CssStyle
 import com.varabyte.kobweb.silk.style.breakpoint.Breakpoint
 import com.varabyte.kobweb.silk.style.toAttrs
 import com.varabyte.kobweb.silk.style.toModifier
-import org.jetbrains.compose.web.css.*
+import org.jetbrains.compose.web.css.em
+import org.jetbrains.compose.web.css.percent
+import org.jetbrains.compose.web.css.px
 import org.jetbrains.compose.web.dom.*
 import strings.ResStrings
-import web.android.dev.pe.Res
 import web.android.dev.pe.components.ConferenceSite
+import web.android.dev.pe.components.widgets.ConvertKitForm
 import web.android.dev.pe.components.widgets.HeadingDecorator
-import web.android.dev.pe.pages.conf.components.sections.SponsorSection
 import web.android.dev.pe.pages.home.components.layouts.TwoPaneSection
 
 @Page("/conf/sponsorship")
@@ -93,10 +94,13 @@ private fun Information() {
     P { Text(ResStrings.conf_sponsorship_p4) }
     SponsorshipPlans()
 
-    SponsorSection(
-        ctaTitle = ResStrings.conf_sponsor_i_want_to_sponsor,
-        ctaPath = Res.Links.Conf.SponsorBrief,
-        modifier = Modifier.padding(0.em).margin(top = 2.em)
+    H2 {
+        HeadingDecorator()
+        Text(ResStrings.conf_sponsor_i_want_to_sponsor)
+    }
+    ConvertKitForm(
+        uid = ResStrings.conf_sponsor_form_uid,
+        modifier = Modifier.margin(topBottom = 1.em)
     )
 }
 

--- a/site/src/jsMain/kotlin/web/android/dev/pe/pages/conf/subpages/sponsorship/SponsorshipPlans.kt
+++ b/site/src/jsMain/kotlin/web/android/dev/pe/pages/conf/subpages/sponsorship/SponsorshipPlans.kt
@@ -1,19 +1,18 @@
 package web.android.dev.pe.pages.conf.subpages.sponsorship
 
 import androidx.compose.runtime.Composable
-import com.varabyte.kobweb.compose.css.*
+import com.varabyte.kobweb.compose.css.BorderCollapse
+import com.varabyte.kobweb.compose.css.FontStyle
+import com.varabyte.kobweb.compose.css.FontWeight
+import com.varabyte.kobweb.compose.css.TextAlign
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.modifiers.*
+import com.varabyte.kobweb.compose.ui.toAttrs
 import com.varabyte.kobweb.silk.components.text.SpanText
 import com.varabyte.kobweb.silk.style.CssStyle
 import com.varabyte.kobweb.silk.style.breakpoint.Breakpoint
 import com.varabyte.kobweb.silk.style.toAttrs
-import org.jetbrains.compose.web.css.AlignContent
-import org.jetbrains.compose.web.css.DisplayStyle
-import org.jetbrains.compose.web.css.LineStyle
-import org.jetbrains.compose.web.css.px
-import org.jetbrains.compose.web.css.rgb
-import org.jetbrains.compose.web.dom.Br
+import org.jetbrains.compose.web.css.*
 import org.jetbrains.compose.web.dom.Div
 import strings.ResStrings
 import web.android.dev.pe.Res
@@ -89,11 +88,12 @@ fun SponsorshipPlans() {
             planC = ""
         )
     }
-    Br()
+    Div(Modifier.height(1.em).toAttrs())
     SpanText(
         text = ResStrings.conf_sponsorship_plan_disclaimer,
         modifier = Modifier.fontStyle(FontStyle.Italic)
     )
+    Div(Modifier.height(2.em).toAttrs())
 }
 
 @Composable

--- a/site/src/jsMain/kotlin/web/android/dev/pe/pages/subscribe/SubscribeForm.kt
+++ b/site/src/jsMain/kotlin/web/android/dev/pe/pages/subscribe/SubscribeForm.kt
@@ -1,23 +1,15 @@
 package web.android.dev.pe.pages.subscribe
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
 import com.varabyte.kobweb.compose.ui.Modifier
-import com.varabyte.kobweb.compose.ui.attrsModifier
-import com.varabyte.kobweb.compose.ui.modifiers.display
-import com.varabyte.kobweb.compose.ui.modifiers.justifyContent
 import com.varabyte.kobweb.compose.ui.modifiers.padding
 import com.varabyte.kobweb.compose.ui.toAttrs
 import com.varabyte.kobweb.core.Page
-import kotlinx.dom.appendElement
-import org.jetbrains.compose.web.css.DisplayStyle
-import org.jetbrains.compose.web.css.JustifyContent
 import org.jetbrains.compose.web.css.em
 import org.jetbrains.compose.web.dom.Div
-import org.w3c.dom.Element
 import web.android.dev.pe.components.MainSite
 import web.android.dev.pe.components.MainSiteNavbar
+import web.android.dev.pe.components.widgets.ConvertKitForm
 
 /**
  * Hiding the primary action because in this page, the "Subscribe" button
@@ -30,40 +22,7 @@ private val CustomNavbar = MainSiteNavbar.copy(primaryLink = null)
 fun SubscribeForm() {
     MainSite(CustomNavbar) {
         Div(Modifier.padding(2.em).toAttrs()) {
-            ConvertKitForm()
+            ConvertKitForm(uid = "f4a99c32b5")
         }
     }
 }
-
-/**
- * Using script to load an inline ConvertKit form. For more info see:
- * https://help.convertkit.com/en/articles/4009572-form-embedding-basics#javascript
- */
-@Composable
-private fun ConvertKitForm() {
-    val containerRef = mutableStateOf(ContainerRef())
-
-    Div(Modifier
-        .display(DisplayStyle.Flex)
-        .justifyContent(JustifyContent.Center)
-        .attrsModifier {
-            ref {
-                containerRef.value = ContainerRef(it)
-                onDispose { containerRef.value = ContainerRef(null) }
-            }
-        }
-        .toAttrs()
-    )
-
-    LaunchedEffect(containerRef.value) {
-        containerRef.value.current?.let { container ->
-            container.appendElement("script") {
-                setAttribute("async", "")
-                setAttribute("data-uid", "f4a99c32b5")
-                setAttribute("src", "https://android-dev-peru.ck.page/f4a99c32b5/index.js")
-            }
-        }
-    }
-}
-
-private class ContainerRef(val current: Element? = null)


### PR DESCRIPTION
## Description

**Proposal:** inline sponsorship form inside the web, rather than redirecting to external Google Form.

## Results

|Before|After|
|-|-|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/0ee1f316-5e8b-45fb-b6b1-259d4b8f4073">|<img width="500" alt="image" src="https://github.com/user-attachments/assets/ea9b7e54-57eb-4cd9-81e6-bc8dd98e424e">|

## Checklist (required)

- [X] I agree with the community code of conduct
- [X] I have executed the `kobweb export --layout static` command and committed the changes (commit message: `chore: publish static files`)