### PR TITLE
chore: update gradle commands to remove warnings from Libre

### DIFF
--- a/site/build.gradle.kts
+++ b/site/build.gradle.kts
@@ -64,15 +64,12 @@ kotlin {
         }
     }
 
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        // Although deprecated in K2, the new suggested approach is not working and still
-        // shows the warning. Seems like a common problem. See:
-        // https://youtrack.jetbrains.com/issue/KT-61573/Emit-the-compilation-warning-on-expect-actual-classes.-The-warning-must-mention-that-expect-actual-classes-are-in-Beta#focus=Comments-27-9822729.0-0
-        @Suppress("DEPRECATION")
-        kotlinOptions {
-            freeCompilerArgs += "-Xexpect-actual-classes"
+    targets.configureEach {
+        compilations.configureEach {
+            compileTaskProvider.get().compilerOptions {
+                freeCompilerArgs.add("-Xexpect-actual-classes")
+            }
         }
-
     }
 
     /**


### PR DESCRIPTION
## Description

Get rid of some warnings. How?

`Libre` multiplatform code generates some warnings we don't care about, so we added a task to hide them. Then we switched to K2 compiler and the warnings were back. There is a new way to fix:

https://youtrack.jetbrains.com/issue/KT-61573/Emit-the-compilation-warning-on-expect-actual-classes.-The-warning-must-mention-that-expect-actual-classes-are-in-Beta#focus=Comments-27-10358357.0-0

## Results

No warnings on compilation

## Checklist (required)

- [X] I agree with the [Code of Conduct](/CODE_OF_CONDUCT.md)
